### PR TITLE
fix(ams): Respect figures' kind, supplement, and counter

### DIFF
--- a/ams/main.typ
+++ b/ams/main.typ
@@ -63,6 +63,28 @@ $ integral_(-oo)^oo e^(-x^2) dif x = sqrt(pi) $
   what we have just done $x^2 = (−x)^2 > 0$. So in all cases $x^2 ≥ 0$.
 ]
 
+#figure(
+  table(
+    columns: (1fr, auto, auto),
+    inset: 10pt,
+    align: horizon,
+    [], [*Area*], [*Parameters*],
+    [*Cylinder*],
+    $ pi h (D^2 - d^2) / 4 $,
+    [
+      $h$: height \
+      $D$: outer radius \
+      $d$: inner radius
+    ],
+    [*Tetrahedron*],
+    $ sqrt(2) / 12 a^3 $,
+    [$a$: edge length]
+  ),
+  caption: "Solids",
+) <table:solids>
+
+You can use tables like @table:solids.
+
 = Introduction
 This is a new section.
 

--- a/ams/template.typ
+++ b/ams/template.typ
@@ -148,9 +148,10 @@
     if it.has("caption") {
       // Gap defaults to 17pt.
       v(if it.has("gap") { it.gap } else { 17pt }, weak: true)
-      smallcaps[Figure]
+      smallcaps(it.supplement)
       if it.numbering != none {
-        [ #counter(figure).display(it.numbering)]
+        [ ]
+        it.counter.display(it.numbering)
       }
       [. ]
       it.caption


### PR DESCRIPTION
## Before

All `figure`s' (equivalent) supplements are `"figure"`, and they share a universal counter. When you reference `table` or something other than `"figure"`, the label (and the counter) differs from what is shown.

![before](https://github.com/typst/templates/assets/73375426/e261ec76-26e2-4269-8aa2-55a7f945e418)

## After

`kind`, `supplement`, and `counter` are respected.

![after](https://github.com/typst/templates/assets/73375426/01b0f3f3-3707-47ce-95ff-54ccb6dd08d6)

## Relevant

- The example of _modifying the appearance_ in [Figure Function – Typst Documentation](https://typst.app/docs/reference/meta/figure/#modifying-appearance).

	```typst
	#show figure: it => align(center)[
	  #it.caption |
	  #emph[
	    #it.supplement
	    #it.counter.display(it.numbering)
	  ]
	  #v(10pt, weak: true)
	  #it.body
	]
	```

- https://github.com/typst/templates/commit/39bcb0aa832dd203fdef8a26ae1532d047066092

Relates-to: #8
