### PR TITLE
Respect IEEE specification for equation references

### DIFF
--- a/ieee/template.typ
+++ b/ieee/template.typ
@@ -22,9 +22,6 @@
   // works.
   bibliography-file: none,
 
-  // Font to be used throughout the document.
-  font: "STIX Two Text",
-
   // The paper's content.
   body
 ) = {
@@ -32,7 +29,7 @@
   set document(title: title, author: authors.map(author => author.name))
 
   // Set the body font.
-  set text(font: font, size: 10pt)
+  set text(font: "STIX Two Text", size: 10pt)
 
   // Configure the page.
   set page(

--- a/ieee/template.typ
+++ b/ieee/template.typ
@@ -22,6 +22,9 @@
   // works.
   bibliography-file: none,
 
+  // Font to be used throughout the document.
+  font: "Times New Roman",
+
   // The paper's content.
   body
 ) = {
@@ -29,7 +32,7 @@
   set document(title: title, author: authors.map(author => author.name))
 
   // Set the body font.
-  set text(font: "STIX Two Text", size: 10pt)
+  set text(font: font, size: 10pt)
 
   // Configure the page.
   set page(
@@ -49,6 +52,25 @@
   // Configure equation numbering and spacing.
   set math.equation(numbering: "(1)")
   show math.equation: set block(spacing: 0.65em)
+
+  // Configure appearance of equation references
+  show ref: it => {
+    let eq = math.equation
+    let el = it.element
+    if el != none and el.func() == eq {
+      // Override equation references.
+      link(
+        el.label,
+        numbering(
+          el.numbering,
+          ..counter(eq).at(el.location())
+        )
+      )
+    } else {
+      // Other references as usual.
+      it
+    }
+  }
 
   // Configure lists.
   set enum(indent: 10pt, body-indent: 9pt)

--- a/ieee/template.typ
+++ b/ieee/template.typ
@@ -52,17 +52,12 @@
 
   // Configure appearance of equation references
   show ref: it => {
-    let eq = math.equation
-    let el = it.element
-    if el != none and el.func() == eq {
+    if it.element != none and it.element.func() == math.equation {
       // Override equation references.
-      link(
-        el.label,
-        numbering(
-          el.numbering,
-          ..counter(eq).at(el.location())
-        )
-      )
+      link(it.element.location(), numbering(
+        it.element.numbering,
+        ..counter(math.equation).at(it.element.location())
+      ))
     } else {
       // Other references as usual.
       it

--- a/ieee/template.typ
+++ b/ieee/template.typ
@@ -23,7 +23,7 @@
   bibliography-file: none,
 
   // Font to be used throughout the document.
-  font: "Times New Roman",
+  font: "STIX Two Text",
 
   // The paper's content.
   body


### PR DESCRIPTION
- IEEE equation references in the text should appear, for example, as "(1)" instead of "Equation 1".
- The example in the Typst documentation shows how to force the reference to use the same numbering as the equation
- However, that example did not include the link to the equation's label