### PR TITLE
do not indent first line for outlines

### DIFF
--- a/ieee/template.typ
+++ b/ieee/template.typ
@@ -154,6 +154,8 @@
   // Start two column mode and configure paragraph properties.
   show: columns.with(2, gutter: 12pt)
   set par(justify: true, first-line-indent: 1em)
+  // Do not indent first line for outlines.
+  show outline: set par(justify: true, first-line-indent: 0em)
   show par: set block(spacing: 0.65em)
 
   // Display abstract and index terms.


### PR DESCRIPTION
fixes https://github.com/typst/templates/issues/21

I am not sure this is the best way to fix it, but it works.