### PR TITLE
Make style closer to IEEE template

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -64,11 +64,10 @@
     }
   )
 
-  // Configure equation numbering and spacing and font.
+  // Configure equation numbering and spacing.
   set math.equation(numbering: "(1)")
   show math.equation: set block(spacing: 0.65em)
-  show math.equation: set text(font: "TeX Gyre Termes Math", size: 10pt)
-  
+
   // Configure appearance of equation references
   show ref: it => {
     if it.element != none and it.element.func() == math.equation {

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -31,7 +31,23 @@
   set document(title: title, author: authors.map(author => author.name))
 
   // Set the body font.
-  set text(font: "STIX Two Text", size: 10pt)
+  set text(font: "TeX Gyre Termes", size: 10pt)
+  
+  // Enums numbering
+  set enum(numbering: "1)a)i)")
+
+  // Tables & figures
+  show figure.where(kind: table): set figure.caption(position: top)
+  show figure.where(kind: table): set text(size: 8pt)
+  show figure.caption.where(kind: table): smallcaps
+  show figure.where(kind: table): set figure(numbering: "I")
+  
+  show figure.where(kind: image): set figure(supplement: [Fig.], numbering: "1", )
+  show figure.where(kind: raw): set figure(supplement: [Fig.], numbering: "1", )
+  show figure.caption: set text(size: 8pt)
+
+  // Code blocks
+  show raw: set text(font: "TeX Gyre Cursor", size: 10pt)
 
   // Configure the page.
   set page(
@@ -48,10 +64,11 @@
     }
   )
 
-  // Configure equation numbering and spacing.
+  // Configure equation numbering and spacing and font.
   set math.equation(numbering: "(1)")
   show math.equation: set block(spacing: 0.65em)
-
+  show math.equation: set text(font: "TeX Gyre Termes Math", size: 10pt)
+  
   // Configure appearance of equation references
   show ref: it => {
     if it.element != none and it.element.func() == math.equation {
@@ -71,7 +88,7 @@
   set list(indent: 10pt, body-indent: 9pt)
 
   // Configure headings.
-  set heading(numbering: "I.A.1.")
+  set heading(numbering: "I.A.a)")
   show heading: it => locate(loc => {
     // Find out the final number of the heading counter.
     let levels = counter(heading).at(loc)
@@ -110,7 +127,7 @@
     ] else [
       // Third level headings are run-ins too, but different.
       #if it.level == 3 {
-        numbering("1)", deepest)
+        numbering("a)", deepest)
         [ ]
       }
       _#(it.body):_
@@ -119,7 +136,7 @@
 
   // Display the paper's title.
   v(3pt, weak: true)
-  align(center, text(18pt, title))
+  align(center, text(24pt, title))
   v(8.35mm, weak: true)
 
   // Display the authors list.
@@ -131,7 +148,7 @@
       columns: slice.len() * (1fr,),
       gutter: 12pt,
       ..slice.map(author => align(center, {
-        text(12pt, author.name)
+        text(9pt, author.name)
         if "department" in author [
           \ #emph(author.department)
         ]
@@ -160,7 +177,7 @@
 
   // Display abstract and index terms.
   if abstract != none [
-    #set text(weight: 700)
+    #set text(9pt, weight: 700)
     #h(1em) _Abstract_---#abstract
 
     #if index-terms != () [
@@ -178,4 +195,5 @@
     set std-bibliography(title: text(10pt)[References], style: "ieee")
     bibliography
   }
+  
 }


### PR DESCRIPTION
From [this reference](https://www.ieee.org/conferences/publishing/templates.html)
- Change fonts to be closer to *Times Roman* and *Courier*
- Update style of figures and table captions 
- Change numbering of `enum`, `headings`, and `captions`
- Increase title font size (`18pt` to `24pt`)
- Decrease font size for `authors`, `abstract` and `index-terms`