### PR TITLE
explicitly select text in appreciated-letter

### DIFF
--- a/appreciated-letter/lib.typ
+++ b/appreciated-letter/lib.typ
@@ -21,7 +21,6 @@
 ) = {
   // Configure page and text properties.
   set page(margin: (top: 2cm))
-  set text(font: "PT Sans")
 
   // Display sender at top of page. If there's no sender
   // add some hidden text to keep the same spacing.

--- a/appreciated-letter/template/main.typ
+++ b/appreciated-letter/template/main.typ
@@ -1,5 +1,7 @@
 #import "@preview/appreciated-letter:0.1.0": letter
 
+#set text(font: "PT Sans")
+
 #show: letter.with(
   sender: [
     Jane Smith, Universal Exports, 1 Heavy Plaza, Morristown, NJ 07964


### PR DESCRIPTION
tried changing font on the letter template, was confused why only my body changed font.

This will break old letters, so does this make this change a 0.2.0?

To keep it 0.1.0, could "fontname" be an argument to the template and then another 'if none' could select PT Mono if the user doesn't ask for something else. Ugly, and I think new arg might also be 0.2.0. 

Or maybe templates should own font like this? Ensure spacing is good.