### PR TITLE
set `raw` figures to be of kind `image`

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -43,7 +43,7 @@
   show figure.where(kind: table): set figure(numbering: "I")
   
   show figure.where(kind: image): set figure(supplement: [Fig.], numbering: "1")
-  show figure.where(kind: raw): set figure(supplement: [Fig.], numbering: "1")
+  show figure.where(kind: raw): set figure(kind: image, supplement: [Fig.], numbering: "1")
   show figure.caption: set text(size: 8pt)
 
   // Code blocks


### PR DESCRIPTION
This results in the figures containing code blocks and figures containing images to share a common counter. This is necessary, as the code blocks (`raw` figures) are also supplemented with `Fig.` in the caption.

Fixes #39