### PR TITLE
Place figures automatically in IEEE

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -37,6 +37,7 @@
   set enum(numbering: "1)a)i)")
 
   // Tables & figures
+  set figure(placement: auto)
   show figure.where(kind: table): set figure.caption(position: top)
   show figure.where(kind: table): set text(size: 8pt)
   show figure.caption.where(kind: table): smallcaps

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -37,7 +37,7 @@
   set enum(numbering: "1)a)i)")
 
   // Tables & figures
-  set figure(placement: auto)
+  set figure(placement: top)
   show figure.where(kind: table): set figure.caption(position: top)
   show figure.where(kind: table): set text(size: 8pt)
   show figure.caption.where(kind: table): smallcaps


### PR DESCRIPTION
According to [the official IEEE template guidelines](https://www.ieee.org/conferences/publishing/templates.html) figures must be placed to the top or bottom of the page. This sets the figure parameter `placement` to `auto` to adhere to this guideline.