### PR TITLE
IEEE: Remove show rule for figure kind `raw`

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -44,7 +44,6 @@
   show figure.where(kind: table): set figure(numbering: "I")
   
   show figure.where(kind: image): set figure(supplement: [Fig.], numbering: "1")
-  show figure.where(kind: raw): set figure(supplement: [Fig.], numbering: "1")
   show figure.caption: set text(size: 8pt)
 
   // Code blocks


### PR DESCRIPTION
As discussed in #40, removing the show rule resolves #39