### PR TITLE
charged-ieee: Fix raw text size

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -47,7 +47,7 @@
   show figure.caption: set text(size: 8pt)
 
   // Code blocks
-  show raw: set text(font: "TeX Gyre Cursor", size: 10pt)
+  show raw: set text(font: "TeX Gyre Cursor", size: 1em / 0.8)
 
   // Configure the page.
   set page(


### PR DESCRIPTION
By default, in Typst, the text size within `raw` elements is 0.8em. In the cherged-ieee template, the text size of `raw`s is the same as the regular text size, which is hard-coded to be 10pt. However, this means `raw`s within figure captions also have a text size of 10pt, even though the outside text has a size of 8pt.

To solve this problem, I replaced `show raw: set text(size: 10pt)` with `show raw: set text(size: 1em / 0.8)`, which essentially cancels the effect of Typst's default show rule for `raw`.