### PR TITLE
charged-ieee: Apply bibliography styling to all bibliographies

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -133,6 +133,10 @@
     ]
   })
 
+  // Style bibliography.
+  show std-bibliography: set text(8pt)
+  set std-bibliography(title: text(10pt)[References], style: "ieee")
+
   // Display the paper's title.
   v(3pt, weak: true)
   align(center, text(24pt, title))
@@ -189,9 +193,5 @@
   body
 
   // Display bibliography.
-  if bibliography != none {
-    show std-bibliography: set text(8pt)
-    set std-bibliography(title: text(10pt)[References], style: "ieee")
-    bibliography
-  }
+  bibliography
 }


### PR DESCRIPTION
Currently, the styling for bibliographies is only applied for content passed through the `bibliography` argument.

With this PR, all bibliographies, whether passed through the `bibliography` parameter, or embedded directly in the document body, will be styled properly.

I kept the `bibliography` argument for backward compatibilities, even though it is not necessary any more. Given the beta nature of the charged-ieee template, the `bibliography` argument could be removed as part of a minor version bump.