### PR TITLE
charged-ieee: Allow passing arbitrary content as author email

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -32,7 +32,7 @@
 
   // Set the body font.
   set text(font: "TeX Gyre Termes", size: 10pt)
-  
+
   // Enums numbering
   set enum(numbering: "1)a)i)")
 
@@ -42,7 +42,7 @@
   show figure.where(kind: table): set text(size: 8pt)
   show figure.caption.where(kind: table): smallcaps
   show figure.where(kind: table): set figure(numbering: "I")
-  
+
   show figure.where(kind: image): set figure(supplement: [Fig.], numbering: "1")
   show figure.caption: set text(size: 8pt)
 
@@ -157,9 +157,13 @@
         if "location" in author [
           \ #author.location
         ]
-        if "email" in author [
-          \ #link("mailto:" + author.email)
-        ]
+        if "email" in author {
+          if type(author.email) == str [
+            \ #link("mailto:" + author.email)
+          ] else [
+            \ #author.email
+          ]
+        }
       }))
     )
 


### PR DESCRIPTION
The README for charged-ieee states that "All keys accept content." However, the `email` key currently only accepts strings. With this PR, I made it possible to pass any content. If a string is specified, a `mailto:` link is created. Otherwise, the content is used as is.