### PR TITLE
Update charged-ieee for Typst 0.12.0

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -118,32 +118,30 @@
     }
 
     set text(10pt, weight: 400)
-    if it.level == 1 [
+    if it.level == 1 {
       // First-level headings are centered smallcaps.
       // We don't want to number the acknowledgment section.
-      #let is-ack = it.body in ([Acknowledgment], [Acknowledgement], [Acknowledgments], [Acknowledgements])
-      #set align(center)
-      #set text(if is-ack { 10pt } else { 11pt })
-      #show: smallcaps
-      #v(15pt, weak: true)
-      #if it.numbering != none and not is-ack {
+      let is-ack = it.body in ([Acknowledgment], [Acknowledgement], [Acknowledgments], [Acknowledgements])
+      set align(center)
+      set text(if is-ack { 10pt } else { 11pt })
+      show: block.with(above: 15pt, below: 13.75pt, sticky: true)
+      show: smallcaps
+      if it.numbering != none and not is-ack {
         numbering("I.", deepest)
         h(7pt, weak: true)
       }
-      #it.body
-      #v(13.75pt, weak: true)
-    ] else if it.level == 2 [
+      it.body
+    } else if it.level == 2 {
       // Second-level headings are run-ins.
-      #set par(first-line-indent: 0pt)
-      #set text(style: "italic")
-      #v(10pt, weak: true)
-      #if it.numbering != none {
+      set par(first-line-indent: 0pt)
+      set text(style: "italic")
+      show: block.with(spacing: 10pt, sticky: true)
+      if it.numbering != none {
         numbering("A.", deepest)
         h(7pt, weak: true)
       }
-      #it.body
-      #v(10pt, weak: true)
-    ] else [
+      it.body
+    } else [
       // Third level headings are run-ins too, but different.
       #if it.level == 3 {
         numbering("a)", deepest)

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -40,6 +40,8 @@
   set enum(numbering: "1)a)i)")
 
   // Tables & figures
+  show figure: set block(spacing: 15.5pt)
+  show figure: set place(clearance: 15.5pt)
   show figure.where(kind: table): set figure.caption(position: top)
   show figure.where(kind: table): set text(size: 8pt)
   show figure.where(kind: table): set figure(numbering: "I")

--- a/charged-ieee/template/main.typ
+++ b/charged-ieee/template/main.typ
@@ -57,6 +57,7 @@ In @fig:sun you can see a common representation of the Sun, which is a star that
 
 #figure(
   caption: [The Planets of the Solar System and Their Average Distance from the Sun],
+  placement: top,
   table(
     // Table styling is not mandated by the IEEE. Feel free to adjust these
     // settings and potentially move them into a set rule.

--- a/charged-ieee/template/main.typ
+++ b/charged-ieee/template/main.typ
@@ -47,7 +47,7 @@ $ a + b = gamma $ <eq:gamma>
 
 #figure(
   placement: none,
-  circle(width: 20%),
+  circle(radius: 15pt),
   caption: [A circle representing the Sun.]
 ) <fig:sun>
 

--- a/charged-ieee/template/main.typ
+++ b/charged-ieee/template/main.typ
@@ -78,7 +78,7 @@ In @fig:sun you can see a common representation of the Sun, which is a star that
   )
 ) <tab:planets>
 
-In @tab:planets, you see the planents of the solar system and their average distance from the Sun.
+In @tab:planets, you see the planets of the solar system and their average distance from the Sun.
 The distances were calculated with @eq:gamma that we presented in @sec:methods.
 
 #lorem(240)

--- a/charged-ieee/typst.toml
+++ b/charged-ieee/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charged-ieee"
-version = "0.1.3"
+version = "0.1.2"
 compiler = "0.12.0"
 entrypoint = "lib.typ"
 repository = "https://github.com/typst/templates"

--- a/charged-ieee/typst.toml
+++ b/charged-ieee/typst.toml
@@ -1,7 +1,7 @@
 [package]
 name = "charged-ieee"
-version = "0.1.2"
-compiler = "0.10.0"
+version = "0.1.3"
+compiler = "0.12.0"
 entrypoint = "lib.typ"
 repository = "https://github.com/typst/templates"
 authors = ["Typst GmbH <https://typst.app>"]


### PR DESCRIPTION
- Use `#set page(columns: 2)` instead of `#show: columns.with(2)` (but keep `#set columns(gutter: ...)` before the `#set page` configuration)
- Use multi-column floats for the document title and authors
- Use contextual functions (`counter(heading).get()`) in show rules instead of `locate()`
- Use `#set par(spacing: ...)`

## Thumbnail

The thumbnail will need to be updated due to small 0.12.0 reflows. Let me know the best way to update that.

## Version

~~I bumped charged-ieee to version 0.1.3, not sure if 0.2.0 would have been more appropriate, though the only "breaking change" here is basically to require Typst 0.12.0+.~~ Undone.