### PR TITLE
Update dashing-dept-news for Typst 0.12.0 (0.11.0+)

### DIFF
--- a/dashing-dept-news/lib.typ
+++ b/dashing-dept-news/lib.typ
@@ -63,15 +63,19 @@
 
     // Display caption.
     if it.has("caption") {
-      set align(center)
-      set text(font: "Syne")
-      v(if it.has("gap") { it.gap } else { 24pt }, weak: true)
-      [-- ]
-      it.caption
-      if it.numbering != none {
-        [ (] + counter(figure).display(it.numbering) + [)]
+      show figure.caption: caption => {
+        set align(center)
+        set text(font: "Syne")
+        [-- ]
+        caption.body
+        if caption.numbering != none {
+          [ (] + numbering(caption.numbering, ..counter(figure).at(it.location())) + [)]
+        }
+        [ --]
       }
-      [ --]
+
+      v(if it.has("gap") { it.gap } else { 24pt }, weak: true)
+      it.caption
     }
 
     v(48pt, weak: true)
@@ -91,7 +95,7 @@
     text(fill: white, weight: "medium", 14pt, align(right + bottom, edition)),
 
     // Hero image.
-    style(styles => {
+    context {
       if hero-image == none {
         return
       }
@@ -103,8 +107,8 @@
         hero-image.image
       }
       let text = text(size: 25pt, fill: white, font: "Syne Tactile", hero-image.caption)
-      let img-size = measure(img, styles)
-      let text-width = measure(text, styles).width + 12pt
+      let img-size = measure(img)
+      let text-width = measure(text).width + 12pt
       let line-length = img-size.height - text-width
 
       grid(
@@ -122,7 +126,7 @@
           line(angle: 90deg, length: line-length, stroke: 3pt + white),
         ),
       )
-    }),
+    },
 
     // Nothing next to the hero image.
     none,
@@ -160,15 +164,15 @@
     },
 
     // The sidebar with articles.
-    locate(loc => {
+    context {
       set text(fill: white, weight: 500)
       show heading: underline.with(stroke: 2pt, offset: 4pt)
       v(44pt)
-      for element in articles.final(loc) {
+      for element in articles.final() {
         element
         v(24pt, weak: true)
       }
-    }),
+    },
   )
 }
 

--- a/dashing-dept-news/typst.toml
+++ b/dashing-dept-news/typst.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dashing-dept-news"
 version = "0.1.0"
-compiler = "0.10.0"
+compiler = "0.11.0"
 entrypoint = "lib.typ"
 repository = "https://github.com/typst/templates"
 authors = ["Typst GmbH <https://typst.app>"]


### PR DESCRIPTION
Nothing had to change for 0.12.0 specifically, so this updates the template to Typst 0.11.0+.

## Noteworthy changes

(Besides replacing things with `context { }`)

- Used `#show figure.caption` for figure caption styling. This changes the styling to what I believe was the original intention (and is what it looks like in Typst 0.7.0 and older).
 
    | Before PR | After PR |
    |--------|--------|
    | ![figure caption displays "Figure 1: caption (1)" - double numbering](https://github.com/user-attachments/assets/3f2557e4-edc8-4327-885f-8ecd118cd3a4) | ![figure caption displays "caption (1)"](https://github.com/user-attachments/assets/0140b9c1-599a-4498-bd13-c5120684474d) |

    Note how the figure number was duplicated starting with Typst 0.8.0, presumably due to the introduction of the `figure.caption` element, which changed the semantics of `it.caption` in the figure show rule as a consequence. With this PR, we revert to the older style (to the right).
