### PR TITLE
Update unequivocal-ams for Typst 0.12.0

### DIFF
--- a/unequivocal-ams/lib.typ
+++ b/unequivocal-ams/lib.typ
@@ -241,7 +241,17 @@
 // And a function for a proof.
 #let proof(body) = block(spacing: 11.5pt, {
   emph[Proof.]
-  [ ] + body
+  [ ]
+  body
+
+  // Add a word-joiner with a 0pt box so the QED symbol is
+  // sent to the next line together with said box (that is,
+  // with nothing else) if it would otherwise collide with text.
+  box(width: 0pt)
   h(1fr)
-  box(scale(160%, origin: bottom + right, sym.square.stroked))
+  sym.wj
+  // Ensure line height isn't affected by our scaling by only
+  // reflowing when scaling the X axis (which is needed so the
+  // QED symbol is sent to the next line if it is too big).
+  box(scale(y: 160%, scale(x: 160%, reflow: true, origin: bottom + right, sym.square.stroked)))
 })

--- a/unequivocal-ams/lib.typ
+++ b/unequivocal-ams/lib.typ
@@ -136,42 +136,33 @@
   // Configure citation and bibliography styles.
   set std.bibliography(style: "springer-mathphys", title: [References])
 
-  show figure: it => block(above: 12.5pt, {
+  set figure(gap: 17pt)
+  show figure: set block(above: 12.5pt, below: 15pt)
+  show figure: it => {
     show: pad.with(x: 23pt)
-    set align(center)
 
-    // Display the figure's body.
-    it.body
-
-    // Display the figure's caption.
-    if it.has("caption") {
-      // Gap defaults to 17pt.
-      v(if it.has("gap") { it.gap } else { 17pt }, weak: true)
-
-      show figure.caption: caption => {
-        smallcaps(caption.supplement)
-        if caption.numbering != none {
-          [ ]
-          numbering(caption.numbering, ..caption.counter.at(it.location()))
-        }
-        [. ]
-        caption.body
+    // Customize the figure's caption.
+    show figure.caption: caption => {
+      smallcaps(caption.supplement)
+      if caption.numbering != none {
+        [ ]
+        numbering(caption.numbering, ..caption.counter.at(it.location()))
       }
-
-      it.caption
+      [. ]
+      caption.body
     }
 
-    v(15pt, weak: true)
-  })
+    // Display the figure's body and caption.
+    it
+  }
 
   // Theorems.
   show figure.where(kind: "theorem"): set align(start)
-  show figure.where(kind: "theorem"): it => block(above: 11.5pt, below: 11.5pt, {
+  show figure.where(kind: "theorem"): it => block(spacing: 11.5pt, {
     strong({
       it.supplement
       if it.numbering != none {
         [ ]
-        counter(heading).display()
         it.counter.display(it.numbering)
       }
       [.]
@@ -244,7 +235,7 @@
   body,
   kind: "theorem",
   supplement: [Theorem],
-  numbering: if numbered { "1" },
+  numbering: if numbered { n => counter(heading).display() + [#n] }
 )
 
 // And a function for a proof.

--- a/unequivocal-ams/lib.typ
+++ b/unequivocal-ams/lib.typ
@@ -198,12 +198,14 @@
   // Display the bibliography, if any is given.
   if bibliography != none {
     show std.bibliography: set text(footnote-size)
-    show std.bibliography: block.with(above: 11pt, inset: (x: 0.5pt))
+    show std.bibliography: set block(above: 11pt)
+    show std.bibliography: pad.with(x: 0.5pt)
     bibliography
   }
 
   // Display details about the authors at the end.
-  show: block.with(above: 12pt, inset: (x: 11.5pt))
+  v(12pt, weak: true)
+  show: pad.with(x: 11.5pt)
   set par(first-line-indent: 0pt)
   set text(script-size)
 
@@ -253,5 +255,11 @@
   // Ensure line height isn't affected by our scaling by only
   // reflowing when scaling the X axis (which is needed so the
   // QED symbol is sent to the next line if it is too big).
-  box(scale(y: 160%, scale(x: 160%, reflow: true, origin: bottom + right, sym.square.stroked)))
+  box(
+    scale(
+      y: 160%,
+      origin: bottom + right,
+      scale(x: 160%, reflow: true, origin: bottom + right, sym.square.stroked)
+    )
+  )
 })

--- a/unequivocal-ams/template/main.typ
+++ b/unequivocal-ams/template/main.typ
@@ -73,7 +73,9 @@ You can use tables like @solids.
     columns: (1fr, auto, auto),
     inset: 5pt,
     align: horizon,
-    [], [*Area*], [*Parameters*],
+    table.header(
+      [], [*Area*], [*Parameters*]
+    ),
     [*Cylinder*],
     $ pi h (D^2 - d^2) / 4 $,
     [$h$: height \
@@ -87,9 +89,9 @@ You can use tables like @solids.
 ) <solids>
 
 == Things that need to be done
-Prove theorems.
+Prove theorems, such as @thm.
 
-#theorem[The Riemann hypothesis is true.]
+#theorem[The Riemann hypothesis is true.] <thm>
 
 #proof[This is left as an exercise to the reader.]
 

--- a/unequivocal-ams/template/main.typ
+++ b/unequivocal-ams/template/main.typ
@@ -89,5 +89,9 @@ You can use tables like @solids.
 == Things that need to be done
 Prove theorems.
 
+#theorem[The Riemann hypothesis is true.]
+
+#proof[This is left as an exercise to the reader.]
+
 = Background
 #lorem(40)

--- a/unequivocal-ams/template/main.typ
+++ b/unequivocal-ams/template/main.typ
@@ -93,7 +93,7 @@ Prove theorems, such as @thm.
 
 #theorem[The Riemann hypothesis is true.] <thm>
 
-#proof[This is left as an exercise to the reader.]
+#proof[This is left as an exercise to the reader, given the complexity of the theorem.]
 
 = Background
 #lorem(40)

--- a/unequivocal-ams/typst.toml
+++ b/unequivocal-ams/typst.toml
@@ -1,7 +1,7 @@
 [package]
 name = "unequivocal-ams"
 version = "0.1.0"
-compiler = "0.10.0"
+compiler = "0.12.0"
 entrypoint = "lib.typ"
 repository = "https://github.com/typst/templates"
 authors = ["Typst GmbH <https://typst.app>"]


### PR DESCRIPTION
- Fixed deprecations (`context`, paragraph spacing)
- Fixed block spacing of figures and bibliography (changing to `#set par(spacing: ...)` seems to have changed all block spacing to match paragraph spacing, which is short in this template)
- Switched to show rule on `figure.caption` for figures (they also now return `it`)
- Used `std.bibliography`
- Fixed figure alignment for theorems
- Moved heading counter display in theorem numbering to the `numbering` function itself so `@references` work

Fixes unrelated to Typst version:
- Fixed theorems not having a space between **Theorem 1.1.** and _Theorem title_.
- Fixed QED symbol colliding with text (Fixes #24)
