### PR TITLE
charged-ieee: Change colon to period in figure caption

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -47,8 +47,7 @@
   show figure.where(kind: table): set figure(numbering: "I")
   show figure.where(kind: image): set figure(supplement: figure-supplement, numbering: "1")
   show figure.caption: set text(size: 8pt)
-  show figure.caption: set align(start)
-  show figure.caption.where(kind: table): set align(center)
+
 
   // Adapt supplement in caption independently from supplement used for
   // references.

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -45,6 +45,7 @@
   show figure.where(kind: table): set figure.caption(position: top)
   show figure.where(kind: table): set text(size: 8pt)
   show figure.where(kind: table): set figure(numbering: "I")
+  show figure.where(kind: table): set figure.caption(separator: [\ ])
   show figure.where(kind: image): set figure(supplement: figure-supplement, numbering: "1")
   show figure.caption: set text(size: 8pt)
   show figure.caption: set align(start)

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -58,7 +58,7 @@
       else [#fig.supplement]
     )
     let numbers = numbering(fig.numbering, ..fig.counter.at(fig.location()))
-    show figure.caption: it => [#prefix~#numbers: #it.body]
+    show figure.caption: it => [#prefix~#numbers. #it.body]
     show figure.caption.where(kind: table): smallcaps
     fig
   }

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -47,7 +47,8 @@
   show figure.where(kind: table): set figure(numbering: "I")
   show figure.where(kind: image): set figure(supplement: figure-supplement, numbering: "1")
   show figure.caption: set text(size: 8pt)
-
+  show figure.caption: set align(start)
+  show figure.caption.where(kind: table): set align(center)
 
   // Adapt supplement in caption independently from supplement used for
   // references.

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -42,10 +42,9 @@
   // Tables & figures
   show figure: set block(spacing: 15.5pt)
   show figure: set place(clearance: 15.5pt)
-  show figure.where(kind: table): set figure.caption(position: top)
+  show figure.where(kind: table): set figure.caption(position: top, separator: [\ ])
   show figure.where(kind: table): set text(size: 8pt)
   show figure.where(kind: table): set figure(numbering: "I")
-  show figure.where(kind: table): set figure.caption(separator: [\ ])
   show figure.where(kind: image): set figure(supplement: figure-supplement, numbering: "1")
   show figure.caption: set text(size: 8pt)
   show figure.caption: set align(start)

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -52,6 +52,7 @@
 
   // Adapt supplement in caption independently from supplement used for
   // references.
+  set figure.caption(separator: [.])
   show figure: fig => {
     let prefix = (
       if fig.kind == table [TABLE]
@@ -59,7 +60,7 @@
       else [#fig.supplement]
     )
     let numbers = numbering(fig.numbering, ..fig.counter.at(fig.location()))
-    show figure.caption: it => [#prefix~#numbers. #it.body]
+    show figure.caption: it => [#prefix~#numbers#figure.caption.separator #it.body]
     show figure.caption.where(kind: table): smallcaps
     fig
   }

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -52,7 +52,7 @@
 
   // Adapt supplement in caption independently from supplement used for
   // references.
-  set figure.caption(separator: [.])
+  set figure.caption(separator: [. ])
   show figure: fig => {
     let prefix = (
       if fig.kind == table [TABLE]
@@ -60,7 +60,7 @@
       else [#fig.supplement]
     )
     let numbers = numbering(fig.numbering, ..fig.counter.at(fig.location()))
-    show figure.caption: it => [#prefix~#numbers#figure.caption.separator #it.body]
+    show figure.caption: it => [#prefix~#numbers#it.separator#it.body]
     show figure.caption.where(kind: table): smallcaps
     fig
   }


### PR DESCRIPTION
According to https://guides.library.uwa.edu.au/IEEE/images_tables_figures, the captions should be centre-justified, and the [IEEE Editorial Manual for Authors](http://journals.ieeeauthorcenter.ieee.org/wp-content/uploads/sites/7/IEEE-Editorial-Style-Manual-for-Authors.pdf) seems to support that idea, although not explicitly


Using "Fig. 1. Caption text." is explicit though.


Feel free to close if not appropriate.