### PR TITLE
Fix str join error when using single index term

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -219,9 +219,12 @@
     #set text(9pt, weight: 700, spacing: 150%)
     #h(1em) _Abstract_---#h(weak: true, 0pt)#abstract
 
-    #if index-terms != () [
+    #if type(index-terms) == str [
+      #h(.3em)_Index Terms_---#h(weak: true, 0pt)#index-terms
+    ] else if index-terms != () [
       #h(.3em)_Index Terms_---#h(weak: true, 0pt)#index-terms.join(", ")
     ]
+
     #v(2pt)
   ]
 


### PR DESCRIPTION
[Link to Issue](https://github.com/typst/templates/issues/65#issue-2876451532)
> If you try entering only one index term, you get this error
> 
> ```
> error: type string has no method `join`
>     ┌─ conf.typ:228:62
>     │
> 228 │       #h(.3em)_Index Terms_---#h(weak: true, 0pt)#index-terms.join(", ")
>     │                                                               ^^^^
> ```
> 
> can be addressed by changing this line in the template:
> 
>     #if index-terms != () [
>       #h(.3em)_Index Terms_---#h(weak: true, 0pt)#index-terms.join(", ")
>     ]
> to
> 
>     #if type(index-terms) == str [
>       #h(.3em)_Index Terms_---#h(weak: true, 0pt)#index-terms
>     ] else if index-terms != () [
>       #h(.3em)_Index Terms_---#h(weak: true, 0pt)#index-terms.join(", ")
>     ]