### PR TITLE
Line spacing fixes for charged-ieee

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -171,7 +171,7 @@
     clearance: 30pt,
     {
       v(3pt, weak: true)
-      align(center, par(leading: 0.5em, text(size: 24pt, title)))
+      align(center, par(leading: 1.2em, text(size: 24pt, title)))
       v(8.35mm, weak: true)
 
       // Display the authors list.

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -139,7 +139,6 @@
       it.body
     } else if it.level == 2 {
       // Second-level headings are run-ins.
-      set par(first-line-indent: 0pt)
       set text(style: "italic")
       show: block.with(spacing: 10pt, sticky: true)
       if it.numbering != none {

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -211,22 +211,23 @@
     }
   )
 
-  // Configure paragraph properties.
-  set par(spacing: 0.45em, justify: true, first-line-indent: 1em, leading: 0.45em)
+  set par(justify: true, first-line-indent: 1em, spacing: 0.5em, leading: 0.5em)
 
   // Display abstract and index terms.
-  if abstract != none [
-    #set text(9pt, weight: 700, spacing: 150%)
-    #h(1em) _Abstract_---#h(weak: true, 0pt)#abstract
+  if abstract != none {
+    set par(spacing: 0.45em, leading: 0.45em, first-line-indent: (amount: 1em, all: true))
+    set text(9pt, weight: 700, spacing: 150%)
 
-    #if index-terms != () [
-      #h(.3em)_Index Terms_---#h(weak: true, 0pt)#index-terms.join(", ")
-    ]
-    #v(2pt)
-  ]
+    [_Abstract_---#h(weak: true, 0pt)#abstract]
+
+    if index-terms != () {
+      parbreak()
+      [_Index Terms_---#h(weak: true, 0pt)#index-terms.join[, ]]
+    }
+    v(2pt)
+  }
 
   // Display the paper's contents.
-  set par(leading: 0.5em)
   body
 
   // Display bibliography.


### PR DESCRIPTION
I fixed the line spacing for the title (I tried to make it correspond to an existing paper, I did not check for an actual value in the LaTeX template).

I fixed the line spacing being higher than the paragraph spacing outside of the abstract. I got the right values from https://github.com/typst/templates/pull/50#issuecomment-2360900172:

> The line with leading .45em applies only to the abstract and a bit further down, I had put .5em to apply to the rest of the document, which is quite close to .5333em

The mistake was introduced in https://github.com/typst/templates/pull/52.