### PR TITLE
Fix charged-ieee title alignment when authors list is omitted 

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -176,8 +176,14 @@
       show std.title: set align(center)
       show std.title: set par(leading: 0.5em)
       show std.title: set text(size: 24pt, weight: "regular")
-      show std.title: set block(below: 8.35mm)
+      show std.title: set block(below: 8.35mm, width: 100%)
+
       std.title()
+
+      if authors.len() == 0 {
+        v(8.35mm)
+      }
+
 
       // Display the authors list.
       set par(leading: 0.6em)

--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -168,7 +168,7 @@
   // spanning all columns (hence floating at the scope of the
   // columns' parent, which is the page).
   place(
-    top,
+    top + center,
     float: true,
     scope: "parent",
     clearance: 30pt,
@@ -176,14 +176,8 @@
       show std.title: set align(center)
       show std.title: set par(leading: 0.5em)
       show std.title: set text(size: 24pt, weight: "regular")
-      show std.title: set block(below: 8.35mm, width: 100%)
-
+      show std.title: set block(below: 8.35mm)
       std.title()
-
-      if authors.len() == 0 {
-        v(8.35mm)
-      }
-
 
       // Display the authors list.
       set par(leading: 0.6em)


### PR DESCRIPTION
Fixes #63

- The block's below spacing isn't being applied if there are no authors, thus a conditional with same length
- The block's width of 100% also fixes the wrong centering