### PR TITLE
adding ORCID icon to authors

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -1,3 +1,4 @@
+#import "@preview/scienceicons:0.1.0": orcid-icon
 // This function gets your whole document as its `body` and formats
 // it as an article in the style of the IEEE.
 #let ieee(
@@ -190,6 +191,10 @@
           gutter: 12pt,
           ..slice.map(author => align(center, {
             text(size: 11pt, author.name)
+            if "orcid" in author {
+              let orcid-green = rgb("#AECD54")
+              link("https://orcid.org/" + author.orcid, orcid-icon(color: orcid-green))
+            }
             if "department" in author [
               \ #emph(author.department)
             ]

--- a/charged-ieee/template/main.typ
+++ b/charged-ieee/template/main.typ
@@ -11,7 +11,8 @@
       department: [Co-Founder],
       organization: [Typst GmbH],
       location: [Berlin, Germany],
-      email: "haug@typst.app"
+      email: "haug@typst.app",
+      orcid: "0000-0000-0000-0000"
     ),
     (
       name: "Laurenz Mädje",


### PR DESCRIPTION
adds the possibility to show and ORCID.org icon with link to profile behind the author name.

If an `orcid` attribute is found in a author description the orcid icon will appear behind the author name.
The icon is a link that points to `https://orcid.org/<author-id>`

example: 
```
(
    name: "Mattis Hasler",
    orcid: "0000-0001-7979-674X"
)
```
will point to: https://orcid.org/0000-0001-7979-674X