### PR TITLE
Add exception for figures without numbering

### DIFF
--- a/charged-ieee/lib.typ
+++ b/charged-ieee/lib.typ
@@ -54,6 +54,9 @@
   // references.
   set figure.caption(separator: [. ])
   show figure: fig => {
+    if fig.numbering == none {
+      return fig
+    }
     let prefix = (
       if fig.kind == table [TABLE]
       else if fig.kind == image [Fig.]


### PR DESCRIPTION
When combining with ctheorems, I've gotten the following error:

```
error: expected string or function, found none
   ┌─ @preview/charged-ieee:0.1.4/lib.typ:62:28
   │
62 │     let numbers = numbering(fig.numbering, ..fig.counter.at(fig.location()))
   │                             ^^^^^^^^^^^^^

help: error occurred while applying show rule to this figure
   ┌─ @preview/ctheorems:1.1.3/lib.typ:85:11
   │
85 │       return figure(
   │ ╭────────────^
86 │ │       result +  // hacky!
87 │ │       fmt(name, number, body, ..args.named()) +
88 │ │       [#metadata(identifier) <meta:thmenvcounter>],
   · │
93 │ │       numbering: refnumbering,
94 │ │     )
```

This can be fixed by handling the case where a figure has no numbering. This PR adds that.