### PR TITLE
unequivocal-ams: Made headings sticky to avoid orphaned headings

### DIFF
--- a/unequivocal-ams/lib.typ
+++ b/unequivocal-ams/lib.typ
@@ -108,19 +108,21 @@
     if it.level == 1 {
       set align(center)
       set text(size: normal-size)
-      smallcaps[
+      block(sticky: true, smallcaps[
         #v(15pt, weak: true)
         #number
         #it.body
         #v(normal-size, weak: true)
-      ]
+      ])
       counter(figure.where(kind: "theorem")).update(0)
     } else {
-      v(11pt, weak: true)
-      number
-      let styled = if it.level == 2 { strong } else { emph }
-      styled(it.body + [. ])
-      h(7pt, weak: true)
+      block(sticky: true, {
+        v(11pt, weak: true)
+        number
+        let styled = if it.level == 2 { strong } else { emph }
+        styled(it.body + [. ])
+        h(7pt, weak: true)
+      })
     }
   }
 

--- a/unequivocal-ams/template/main.typ
+++ b/unequivocal-ams/template/main.typ
@@ -79,8 +79,8 @@ You can use tables like @solids.
     [*Cylinder*],
     $ pi h (D^2 - d^2) / 4 $,
     [$h$: height \
-     $D$: outer radius \
-     $d$: inner radius],
+      $D$: outer radius \
+      $d$: inner radius],
     [*Tetrahedron*],
     $ sqrt(2) / 12 a^3 $,
     [$a$: edge length]
@@ -96,4 +96,5 @@ Prove theorems, such as @thm.
 #proof[This is left as an exercise to the reader, given the complexity of the theorem.]
 
 = Background
-#lorem(40)
+#lorem(187)
+


### PR DESCRIPTION
Making headings sticky to avoid orphaned headings.

Typst headings are wrapped in sticky blocks by default to avoid orphaned headings.  The show rule that configures the AMS style headings access the body element directly, which removed the sticky behavior.  This updates adds a sticky block into the show rule to restore the default behavior.  This technique is recommended in the Typst documentation: https://typst.app/docs/reference/model/heading/

Changes: 
Updated unequivocal-ams/lib.typ to add sticky blocks around headings.

Updated unequivocal-ams/template/main.typ to demonstrate sticky headings.  With the previous template, the "REFERENCES" heading is orphaned.  With the new template, it is no longer orphaned.  To see the updated behavior, you'll need to point the import to the lib.typ file directly, instead of loading from @preview.

